### PR TITLE
Person and Organization #find_by_name through #search

### DIFF
--- a/lib/pipedrive/organization.rb
+++ b/lib/pipedrive/organization.rb
@@ -23,6 +23,19 @@ module Pipedrive
         find_by_name(name).first || create(opts.merge(:name => name))
       end
 
+      def search(opts)
+        res = get "#{resource_path}/search", query: opts
+        res.success? ? res['data'] : bad_response(res,opts)
+      end
+
+      def find_by_name(name, opts={})
+        res = search({ term: name, fields: "name", exact_match: true }.merge(opts))
+
+        return unless org_id = res.fetch("items", nil)&.first&.fetch("item", nil)&.fetch("id", nil)
+
+        find(org_id)
+      end
+
     end
   end
 end

--- a/lib/pipedrive/person.rb
+++ b/lib/pipedrive/person.rb
@@ -7,6 +7,19 @@ module Pipedrive
         find_by_name(name, :org_id => opts[:org_id]).first || create(opts.merge(:name => name))
       end
 
+      def search(opts)
+        res = get "#{resource_path}/search", query: opts
+        res.success? ? res['data'] : bad_response(res,opts)
+      end
+
+      def find_by_name(name, opts={})
+        res = search({ term: name, fields: "name", exact_match: true }.merge(opts))
+
+        return unless person_id = res.fetch("items", nil)&.first&.fetch("item", nil)&.fetch("id", nil)
+
+        find(person_id)
+      end
+
     end
 
     def deals()


### PR DESCRIPTION
The existing [Pipedrive::Base#find_by_name](https://github.com/Bulletproof-Dev/pipedrive-ruby/blob/master/lib/pipedrive/base.rb#L153) is using a deprecated endpoint.

In order to make the minimal disruptive change, I have added a #find_by_name method to both `Person` and `Organization` which make use of the new `/search` endpoints. They will also exact match on the given name and return the record, if found.

Pipedrive API endpoint deprecation info: https://developers.pipedrive.com/changelog/post/removal-of-the-find-searchresults-and-searchresultsfield-endpoints-replaced-by-6-new-endpoints